### PR TITLE
feat: show youngest philosophers first

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -191,7 +191,7 @@ export default function App() {
   const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === 'true');
   const [selectedGroup, setSelectedGroup] = useState('');
   const [selectedRegion, setSelectedRegion] = useState('');
-  const [sortBy, setSortBy] = useState('oldest_first'); // Pakeista numatytoji reikšmė
+  const [sortBy, setSortBy] = useState('youngest_first'); // Default to youngest first
   const [selectedChronologicalOrder, setSelectedChronologicalOrder] = useState('');
   const [modalContent, setModalContent] = useState({ philosopher: null, contentType: null });
   // Pridėta: slapukų būsena
@@ -220,12 +220,12 @@ export default function App() {
       }
       setSelectedRegion('');
       setSelectedChronologicalOrder('');
-      setSortBy('oldest_first'); // Pakeista numatytoji reikšmė
+      setSortBy('youngest_first'); // Default sorting when navigating with group param
     } else if (location.pathname !== '/philosophers') {
       setSelectedGroup('');
       setSelectedRegion('');
       setSelectedChronologicalOrder('');
-      setSortBy('oldest_first'); // Pakeista numatytoji reikšmė, kad atitiktų
+      setSortBy('youngest_first'); // Default sorting when leaving philosophers page
     }
   }, [location.search, location.pathname]);
 
@@ -270,7 +270,7 @@ export default function App() {
     setSelectedGroup('');
     setSelectedRegion('');
     setSelectedChronologicalOrder('');
-    setSortBy('oldest_first'); // Pakeista numatytoji reikšmė
+    setSortBy('youngest_first'); // Reset sorting to youngest first
   }, []);
 
   // Funkcija slapukų sutikimui


### PR DESCRIPTION
### **User description**
## Summary
- default philosophers list sort order set to youngest first
- ensure navigation and filter resets keep youngest-first ordering

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688c45a72494832c8e3ce4b983f45163


___

### **PR Type**
Enhancement


___

### **Description**
- Changed default philosopher sorting from oldest-first to youngest-first

- Updated filter reset behavior to maintain youngest-first ordering

- Modified navigation state handling to preserve new default sort


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Default Sort State"] --> B["youngest_first"]
  C["Filter Reset"] --> B
  D["Navigation Reset"] --> B
  B --> E["Philosophers Display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.jsx</strong><dd><code>Update default sorting to youngest first</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.jsx

<ul><li>Changed initial <code>sortBy</code> state from 'oldest_first' to 'youngest_first'<br> <li> Updated navigation effect to set youngest-first when navigating with <br>group param<br> <li> Modified filter clear function to reset to youngest-first sorting<br> <li> Updated navigation reset to use youngest-first when leaving <br>philosophers page</ul>


</details>


  </td>
  <td><a href="https://github.com/Jeshki/dusofi-full/pull/11/files#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

