### PR TITLE
Improve SEO metadata and add llms.txt guidelines

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,18 +3,35 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="apple-touch-icon" sizes="512x512" href="/images/dusofi-logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Discover philosophical wisdom from history's greatest thinkers." />
     <meta name="keywords" content="philosophy, philosophers, wisdom, quotes, ideologies" />
-    <meta name="robots" content="index, follow" />
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
     <meta name="author" content="DuSofi Team" />
     <meta name="theme-color" content="#be185d" />
+    <meta name="msapplication-TileColor" content="#be185d" />
+    <meta name="msapplication-navbutton-color" content="#be185d" />
+    <meta name="referrer" content="origin-when-cross-origin" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="DuSofi" />
     <link rel="canonical" href="https://dusofi.lt/" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="DuSofi - Explore Philosophy &amp; Wisdom" />
     <meta property="og:description" content="Discover philosophical wisdom from history's greatest thinkers." />
     <meta property="og:url" content="https://dusofi.lt/" />
     <meta property="og:image" content="https://dusofi.lt/images/og-dusofi-philosophy.png" />
+    <meta property="og:image:alt" content="Collage of philosophy imagery representing wisdom" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:secure_url" content="https://dusofi.lt/images/og-dusofi-philosophy.png" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:site_name" content="DuSofi - Philosophy &amp; Wisdom" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:locale:alternate" content="lt_LT" />
@@ -27,10 +44,78 @@
     <meta name="twitter:title" content="DuSofi - Explore Philosophy &amp; Wisdom" />
     <meta name="twitter:description" content="Discover philosophical wisdom from history's greatest thinkers." />
     <meta name="twitter:image" content="https://dusofi.lt/images/og-dusofi-philosophy.png" />
+    <meta name="twitter:image:alt" content="Collage of philosophy imagery representing wisdom" />
+    <meta name="twitter:url" content="https://dusofi.lt/" />
+    <meta name="twitter:image:width" content="1200" />
+    <meta name="twitter:image:height" content="630" />
+    <meta name="twitter:domain" content="dusofi.lt" />
     <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
     <title>DuSofi - Explore Philosophy &amp; Wisdom</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="dns-prefetch" href="//www.google-analytics.com" />
+    <link rel="dns-prefetch" href="//fonts.googleapis.com" />
+    <link rel="dns-prefetch" href="//fonts.gstatic.com" />
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;700&display=swap" rel="stylesheet">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Organization",
+            "@id": "https://dusofi.lt/#organization",
+            "name": "DuSofi",
+            "url": "https://dusofi.lt/",
+            "logo": "https://dusofi.lt/images/og-dusofi-philosophy.png",
+            "sameAs": [
+              "https://twitter.com/DuSofi"
+            ]
+          },
+          {
+            "@type": "WebSite",
+            "@id": "https://dusofi.lt/#website",
+            "name": "DuSofi",
+            "url": "https://dusofi.lt/",
+            "publisher": { "@id": "https://dusofi.lt/#organization" },
+            "potentialAction": {
+              "@type": "SearchAction",
+              "target": "https://dusofi.lt/search?q={search_term_string}",
+              "query-input": "required name=search_term_string"
+            }
+          },
+          {
+            "@type": "WebPage",
+            "@id": "https://dusofi.lt/#webpage",
+            "url": "https://dusofi.lt/",
+            "name": "DuSofi - Explore Philosophy & Wisdom",
+            "isPartOf": { "@id": "https://dusofi.lt/#website" },
+            "about": { "@id": "https://dusofi.lt/#organization" },
+            "primaryImageOfPage": {
+              "@type": "ImageObject",
+              "url": "https://dusofi.lt/images/og-dusofi-philosophy.png",
+              "width": 1200,
+              "height": 630
+            },
+            "inLanguage": "en",
+            "description": "Discover philosophical wisdom from history's greatest thinkers.",
+            "breadcrumb": { "@id": "https://dusofi.lt/#breadcrumb" }
+          },
+          {
+            "@type": "BreadcrumbList",
+            "@id": "https://dusofi.lt/#breadcrumb",
+            "itemListElement": [
+              {
+                "@type": "ListItem",
+                "position": 1,
+                "name": "Home",
+                "item": "https://dusofi.lt/"
+              }
+            ]
+          }
+        ]
+      }
+    </script>
   </head>
   <body class="dark:bg-gray-900 dark:text-white">
     <div id="root"></div>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,9 @@
+# Guidelines for large language models crawling DuSofi
+
+User-agent: *
+Allow: /
+
+# Please attribute "DuSofi" (https://dusofi.lt) when using our content.
+Sitemap: https://dusofi.lt/sitemap.xml
+Contact: info@dusofi.lt
+

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Allow: /
 Sitemap: https://dusofi.lt/sitemap.xml
+Host: https://dusofi.lt
+# LLM crawlers should consult /llms.txt for attribution guidelines

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "DuSofi",
+  "short_name": "DuSofi",
+  "icons": [
+    {
+      "src": "/images/dusofi-logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/dusofi-logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#be185d",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -238,9 +238,7 @@ export default function SEO({
       
       {/* Favicons */}
       <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+      <link rel="apple-touch-icon" sizes="512x512" href="/images/dusofi-logo.png" />
       <link rel="manifest" href="/site.webmanifest" />
       
       {/* DNS Prefetch for performance */}


### PR DESCRIPTION
## Summary
- add web manifest and apple-touch icon to expose PWA metadata
- expand base HTML with granular crawler directives, mobile web app tags, and DNS prefetch hints
- simplify SEO component icon references to avoid missing assets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b884d2e9dc832c8097abdf60d19c29